### PR TITLE
feat: 로그인 및 내 여행목록 페이지에서 뒤로가기 시 종료 구현

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-EXPO_PUBLIC_BASE_URL=https://yeogidot-frontend.jihongeek.workers.dev/my-travel
+EXPO_PUBLIC_BASE_URL=https://yeogidot-frontend.jihongeek.workers.dev

--- a/App.tsx
+++ b/App.tsx
@@ -34,7 +34,8 @@ function AppContent() {
   }, []);
 
   const isHome = (homeURLs: string[], url: string) => {
-    return homeURLs.some((homeURL) => url === homeURL);
+    const normalize = (u: string) => u.replace(/\/$/, '');
+    return homeURLs.some((homeURL) => normalize(url) === normalize(homeURL));
   };
 
   const insets = useSafeAreaInsets();

--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { StyleSheet, View, BackHandler, Platform, Text, Dimensions } from 'react-native';
+import { StyleSheet, View, BackHandler, Platform, Text } from 'react-native';
 import { SafeAreaProvider, SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   WebView,
@@ -33,9 +33,14 @@ function AppContent() {
       });
   }, []);
 
+  const isHome = (homeURLs: string[], url: string) => {
+    return homeURLs.some((homeURL) => url === homeURL);
+  };
+
   const insets = useSafeAreaInsets();
-  const baseUrl = process.env.EXPO_PUBLIC_BASE_URL;
-  if (!baseUrl)
+  const baseURL = process.env.EXPO_PUBLIC_BASE_URL;
+  const homeURLs = [`${baseURL}/my-travel`, `${baseURL}/login`, baseURL];
+  if (!baseURL)
     return (
       <View style={styles.errorContainer}>
         <Text>Error: EXPO_PUBLIC_BASE_URL is not defined in .env</Text>
@@ -131,7 +136,7 @@ function AppContent() {
   useEffect(() => {
     let backHandler: any;
     const onBackPress = () => {
-      if (canGoBack && webViewRef.current) {
+      if (canGoBack && webViewRef.current?.goBack) {
         webViewRef.current.goBack();
         return true;
       }
@@ -169,17 +174,19 @@ function AppContent() {
     return <View style={styles.container} />; // Render empty view while parsing the initial URL
   }
 
-  const targetUri = buildWebViewTargetUri(baseUrl, initialRoute);
+  const targetUri = buildWebViewTargetUri(baseURL, initialRoute);
 
   return (
     <SafeAreaView style={styles.container}>
       <StatusBar style='auto' />
       <WebView
         ref={webViewRef}
-        key={baseUrl}
+        key={baseURL}
         source={{ uri: targetUri }}
         onNavigationStateChange={(navState: WebViewNavigation) => {
-          setCanGoBack(navState.canGoBack);
+          setCanGoBack(
+            isHome(homeURLs, navState.url) ? false : navState.canGoBack,
+          );
         }}
         javaScriptEnabled={true}
         domStorageEnabled={true}

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "여기닷",
     "slug": "yeogidot",
-    "version": "1.0.0",
+    "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "plugins": [

--- a/app.json
+++ b/app.json
@@ -43,6 +43,7 @@
       "bundleIdentifier": "com.yeogidot.app"
     },
     "android": {
+      "versionCode" : 3,
       "adaptiveIcon": {
         "backgroundColor": "#ffffff",
         "foregroundImage": "./assets/android-icon-foreground.png",

--- a/utils/webview.ts
+++ b/utils/webview.ts
@@ -40,13 +40,13 @@ export function parseDeepLinkToAppRoute(url: string | null): string | null {
 }
 
 export function buildWebViewTargetUri(
-  baseUrl: string,
-  initialRoute: string | null
+  baseURL: string,
+  initialRoute: string | null,
 ): string {
   if (!initialRoute) {
-    return baseUrl;
+    return baseURL;
   }
-  const originMatch = baseUrl.match(HTTP_ORIGIN_REGEX);
-  const origin = originMatch ? originMatch[0] : baseUrl;
+  const originMatch = baseURL.match(HTTP_ORIGIN_REGEX);
+  const origin = originMatch ? originMatch[0] : baseURL;
   return `${origin}${initialRoute}`;
 }


### PR DESCRIPTION
앱을 사용할 때, 연속 뒤로가기로 종료하는 경우 계속 로그인 페이지나 이전 페이지로 계속 돌아가는 것보다 
내 여행목록 페이지나 로그인 페이지의 경우 즉시 종료 의사 모달을 볼 수 있게 수정하였습니다.

https://github.com/user-attachments/assets/6acea6e5-c474-4ae9-a762-f4f1692ccd97

